### PR TITLE
Modificación al script de creación de la base de datos.

### DIFF
--- a/database_Backup/database_backup.sql
+++ b/database_Backup/database_backup.sql
@@ -37,7 +37,7 @@ CREATE TABLE `clientes` (
   `direccion_cliente` varchar(255) NOT NULL,
   `status_cliente` tinyint(4) NOT NULL,
   `date_added` datetime NOT NULL,
-  `id_moneda` int(2) NOT NULL
+  `id_moneda` int(2) NOT NULL DEFAULT 2,
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --


### PR DESCRIPTION
Se agregó al campo id_moneda de la tabla clientes el valor por default a
colones (2). Sino al restaurar la base de datos y correr el programa da
un error.